### PR TITLE
Parse default parameters

### DIFF
--- a/json2args/parameter.py
+++ b/json2args/parameter.py
@@ -5,6 +5,8 @@ parse the tool configuration and the parameters.
 import os
 import json
 from yaml import load, Loader
+from itertools import chain
+
 import numpy as np
 import pandas as pd
 
@@ -28,7 +30,7 @@ def read_config() -> dict:
 def _parse_param(key: str, val: str, param_config: dict):
     # switch the type
     c = param_config[key]
-
+    
     # handle arrays
     # TODO: add an optional shape parameter. if set -> np.flatten().reshape(shape)
     if isinstance(val, (list, tuple)):
@@ -80,9 +82,15 @@ def get_parameter() -> dict:
 
     # container for parsed arguments
     kwargs = {}
-    
+
+    # get all parameters from param_config that have a default value and are not optional to parse default values
+    default_params = {name: x.get('default') for name, x in param_conf.items()  if x.get('default') is not None and 'optional' not in x.keys()}
+
+    # combine parameters from param_file and default parameters
+    params2parse = chain(p[section].items(), default_params.items())
+
     # parse all parameter
-    for key, value in p[section].items():
+    for key, value in params2parse:
         kwargs[key] = _parse_param(key, value, param_conf)
 
     return kwargs

--- a/json2args/parameter.py
+++ b/json2args/parameter.py
@@ -84,7 +84,7 @@ def get_parameter() -> dict:
     kwargs = {}
 
     # get all parameters from param_config that have a default value and are not optional to parse default values
-    default_params = {name: x.get('default') for name, x in param_conf.items() if x.get('default') is not None and x.get('optional')==False}
+    default_params = {name: x.get('default') for name, x in param_conf.items() if x.get('default') is not None and x.get('optional', False)==False}
 
     # combine parameters from param_file and default parameters
     params2parse = chain(p[section].items(), default_params.items())

--- a/json2args/parameter.py
+++ b/json2args/parameter.py
@@ -30,7 +30,7 @@ def read_config() -> dict:
 def _parse_param(key: str, val: str, param_config: dict):
     # switch the type
     c = param_config[key]
-    
+
     # handle arrays
     # TODO: add an optional shape parameter. if set -> np.flatten().reshape(shape)
     if isinstance(val, (list, tuple)):
@@ -84,7 +84,7 @@ def get_parameter() -> dict:
     kwargs = {}
 
     # get all parameters from param_config that have a default value and are not optional to parse default values
-    default_params = {name: x.get('default') for name, x in param_conf.items()  if x.get('default') is not None and 'optional' not in x.keys()}
+    default_params = {name: x.get('default') for name, x in param_conf.items() if x.get('default') is not None and x.get('optional')==False}
 
     # combine parameters from param_file and default parameters
     params2parse = chain(p[section].items(), default_params.items())


### PR DESCRIPTION
This PR implements parsing default values of parameters. Default parameters are only parsed if they are not optional.

The following default parameters defined in `tool.yml` are parsed:
```yml
startdate:
        type: string
        default: "2001-01-02T08:30:00"
        optional: false
```
```yml
startdate:
        type: string
        default: "2001-01-02T08:30:00"
```
If `optional: true`, the default value of the parameter is not parsed:
```yml
startdate:
        type: string
        default: "2001-01-02T08:30:00"
        optional: true
```
@mmaelicke we can discuss the behavior of not parsing optional values. Do we need this logic? In general it does not really make sense to set parameters with a default value as optional...